### PR TITLE
Switch from deprecated arma::is_finite() to std::isfinite()

### DIFF
--- a/src/02_algebrahelpers_RcppHelpers.cpp
+++ b/src/02_algebrahelpers_RcppHelpers.cpp
@@ -256,7 +256,7 @@ arma::mat solve_symmetric_cpp_matrixonly_withcheck(
     bool& proper,
     bool approx = true
 ){
-  double sqrt_epsilon  = 1.490116e-08;
+  //double sqrt_epsilon  = 1.490116e-08;
   int i,j;
   int nvar = X.n_cols;
   
@@ -294,7 +294,7 @@ arma::mat solve_symmetric_cpp_matrixonly_withcheck(
     proper = false;
     for (i=0;i<nvar;i++){
       for (j=0;j<nvar;j++){
-        if (!is_finite(X(i,j))){
+        if (!std::isfinite(X(i,j))){
           if (i==j){
             X(i,j) = 1;
           } else {

--- a/src/06_ULS_fitfunction_cpp.cpp
+++ b/src/06_ULS_fitfunction_cpp.cpp
@@ -59,7 +59,7 @@ double ULS_Gauss_cpp_pergroup(
     arma::mat tau = grouplist["tau"];
     
     for (i = 0; i < nvar; i++){
-      if (is_finite(means(i))){
+      if (std::isfinite(means(i))){
         // FIXME:  This is just silly ...
         arma::vec obselem(1);
         obselem(0) = means(i);

--- a/src/06_ULS_gradient_cpp.cpp
+++ b/src/06_ULS_gradient_cpp.cpp
@@ -60,7 +60,7 @@ arma::mat ULS_Gauss_gradient_pergroup_cpp(
     arma::mat tau = grouplist["tau"];
     
     for (i = 0; i < nvar; i++){
-      if (is_finite(means(i))){
+      if (std::isfinite(means(i))){
         // FIXME:  This is just silly ...
         arma::vec obselem(1);
         obselem(0) = means(i);

--- a/src/06_WLS_Wmat.cpp
+++ b/src/06_WLS_Wmat.cpp
@@ -36,7 +36,7 @@ arma::mat WLS_wmat(
         }
         
         // Check for NA:
-        if (arma::is_finite(data(p,g)) && arma::is_finite(data(p,h))){
+        if (std::isfinite(data(p,g)) && std::isfinite(data(p,h))){
           sec(g,h) += std::pow((double)ncase,-1.0) * (data(p,g) - means(g)) * (data(p,h) - means(h));
           for (i = 0; i < nvar; i++){
             if (p==0){
@@ -44,7 +44,7 @@ arma::mat WLS_wmat(
             }
             
             // Check NA:
-            if (arma::is_finite(data(p,i))){
+            if (std::isfinite(data(p,i))){
               thi(g,h,i) += std::pow((double)ncase,-1.0) * (data(p,g) - means(g)) * (data(p,h) - means(h)) * (data(p,i) - means(i)) ;
               for (j = i; j < nvar; j ++){
                 if (p==0){
@@ -52,7 +52,7 @@ arma::mat WLS_wmat(
                 }
                 
                 // Check NA:
-                if (arma::is_finite(data(p,j))){
+                if (std::isfinite(data(p,j))){
                   four(i,j,g,h) +=  std::pow((double)ncase,-1.0) *(data(p,i) - means(i)) * (data(p,j) - means(j)) * (data(p,g) - means(g)) * (data(p,h) - means(h)); 
                 }
               }

--- a/src/14_varcov_derivatives_cpp.cpp
+++ b/src/14_varcov_derivatives_cpp.cpp
@@ -219,7 +219,7 @@ arma::mat d_phi_theta_varcov_group_cpp(
     
     for (j = 0; j < tauncols && noThresholds; j++){
       
-      if (is_finite(tau(i,j))){
+      if (std::isfinite(tau(i,j))){
         noThresholds = false;
       }
     }  
@@ -242,12 +242,12 @@ arma::mat d_phi_theta_varcov_group_cpp(
   
   for (i=0;i<nvar;i++){
     
-    if (arma::is_finite(mu(i,0))){
+    if (std::isfinite(mu(i,0))){
       nMean++;
     }
     
     for (j = 0; j < nrow_tau; j++){
-      if (arma::is_finite(tau(j,i))){
+      if (std::isfinite(tau(j,i))){
         nThresh++;
       }
     }


### PR DESCRIPTION
Armadillo 15.0.* now makes C++14 the minimum compilation standard, which also means I can no-longer add the suppression of deprecation warnings (which used a macro before and now use a C++14 or later attribute). For most packages, adapting to it can be fairly simple, and yours is one of them -- in fact it is just a few statements across five files. In the patch below we simply update this as now required by Armadillo 15.0.x.  (I also suppressed on 'unused variable' warning by commenting the assignment out.)

Please see issues [#475](https://github.com/RcppCore/RcppArmadillo/issues/475) and below at the RcppArmadillo GitHub repo for context, and notably [#491](https://github.com/RcppCore/RcppArmadillo/issues/491) for this second wave of PRs and patches (following one for moving away from C++11, something your package does not need). It would be terrific if you could make an upload to CRAN 'soon' to remove the deprecation warning. Please do not hesitate to reach out if I can assist in any way or clarify matters -- see also [this blog post from yesterday](http://dirk.eddelbuettel.com/blog/2025/10/10#rcpparmadillo_15_transition_office_hours) and the [corresponding email to the r-package-devel list](https://stat.ethz.ch/pipermail/r-package-devel/2025q4/012051.html) -- I can offer help in informal 'office hours' over zoom or google meet.